### PR TITLE
Wrist, second speed using slot1 for L1coral and shoot at net 

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -17,6 +17,7 @@ import static edu.wpi.first.units.Units.Meters;
 
 import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.configs.Slot1Configs;
 import com.pathplanner.lib.path.PathConstraints;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -186,10 +187,12 @@ public final class Constants {
     // public static final double CANCODER_FACTOR = 1.4634 / 0.02197;
     public static final Slot0Configs SLOT0_CONFIGS =
         new Slot0Configs().withKP(120).withKI(0).withKD(0).withKS(0).withKV(0).withKA(0);
+    public static final Slot1Configs SLOT1_CONFIGS =
+        new Slot1Configs().withKP(50).withKI(0).withKD(0).withKS(0).withKV(0).withKA(0);
     public static final MotionMagicConfigs MOTIONMAGIC_CONFIGS =
         new MotionMagicConfigs()
-            .withMotionMagicCruiseVelocity(40) // 60  5
-            .withMotionMagicAcceleration(100) // 240  15
+            .withMotionMagicCruiseVelocity(50) // 60  5
+            .withMotionMagicAcceleration(70) // 240  15
             .withMotionMagicJerk(400);
   }
 
@@ -389,15 +392,15 @@ public final class Constants {
     public static final List<Pose2d> blueBargePoses =
         new ArrayList<Pose2d>() {
           {
-            add(new Pose2d(8.06, 5, new Rotation2d(Units.degreesToRadians(181))));
-            add(new Pose2d(8.06, 6.5, new Rotation2d(Units.degreesToRadians(181))));
+            add(new Pose2d(8.187, 5, new Rotation2d(Units.degreesToRadians(181))));
+            add(new Pose2d(8.187, 6.5, new Rotation2d(Units.degreesToRadians(181))));
           }
         };
     public static final List<Pose2d> redBargePoses =
         new ArrayList<Pose2d>() {
           {
-            add(new Pose2d(9.490, 3, new Rotation2d(Units.degreesToRadians(1))));
-            add(new Pose2d(9.490, 1.5, new Rotation2d(Units.degreesToRadians(1))));
+            add(new Pose2d(9.363, 3, new Rotation2d(Units.degreesToRadians(1))));
+            add(new Pose2d(9.363, 1.5, new Rotation2d(Units.degreesToRadians(1))));
           }
         };
   }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -15,6 +15,7 @@ package frc.robot;
 
 import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.CANBus.CANBusStatus;
+import com.ctre.phoenix6.SignalLogger;
 import com.ctre.phoenix6.swerve.SwerveModuleConstants;
 import com.ctre.phoenix6.swerve.SwerveModuleConstants.DriveMotorArrangement;
 import com.ctre.phoenix6.swerve.SwerveModuleConstants.SteerMotorArrangement;
@@ -87,6 +88,10 @@ public class Robot extends LoggedRobot {
         break;
     }
 
+    // uncomment the line below to log CTRE devices to usb stick
+    SignalLogger.setPath("//media/sda1/logs");
+    // do not call the setPath and will be logged to rio at "/home/lvuser/logs"
+
     // Start AdvantageKit logger
     Logger.start();
 
@@ -131,6 +136,8 @@ public class Robot extends LoggedRobot {
     // 0))});
     // Logger.recordOutput(
     //    "RobotPose/Zero3d", new Pose3d[] {new Pose3d(0, 0, 0, new Rotation3d(0, 0, 0))});
+
+    SignalLogger.start();
   }
 
   /** This function is called periodically during all modes. */

--- a/src/main/java/frc/robot/commands/ManipulatorCommands.java
+++ b/src/main/java/frc/robot/commands/ManipulatorCommands.java
@@ -119,7 +119,11 @@ public class ManipulatorCommands {
           Command command;
           Command ledShooting =
               Commands.runOnce(() -> LEDSegment.all.setColor(LightsSubsystem.green));
-          Command ledShot = Commands.runOnce(() -> LEDSegment.all.disableLEDs());
+          Command afterShot =
+              Commands.parallel(
+                  Commands.runOnce(() -> havePiece = false),
+                  Commands.runOnce(() -> indexing = false),
+                  Commands.runOnce(() -> LEDSegment.all.disableLEDs()));
           command = Commands.none();
           if (Constants.WRIST.POSITION_SCORING_ELEMENT == "Algae") {
             ///// SHOOT ALGAE PROCESSOR /////
@@ -188,7 +192,7 @@ public class ManipulatorCommands {
                     Commands.runOnce(() -> myElevatorWrist.setLookingToShoot(false)));
           }
           // execute sequence
-          return ledShooting.andThen(command).andThen(ledShot);
+          return ledShooting.andThen(command).andThen(afterShot);
         },
         Set.of(myIntake, myElevatorWrist));
   }

--- a/src/main/java/frc/robot/commands/ManipulatorCommands.java
+++ b/src/main/java/frc/robot/commands/ManipulatorCommands.java
@@ -141,7 +141,7 @@ public class ManipulatorCommands {
                     Commands.runOnce(
                         () -> Logger.recordOutput("Manipulator/ElevatorWristState", "ShootNet")),
                     myElevatorWrist.setPositionCmdNew(
-                        myIntakeLow, Constants.ELEVATOR.SHOOTNET, Constants.WRIST.SHOOTNET),
+                        Constants.ELEVATOR.SHOOTNET, Constants.WRIST.SHOOTNET),
                     Commands.sequence(
                         Commands.waitSeconds(Constants.INTAKE_SHOOTER.ALGAE_NET_SHOOT_DELAY),
                         myIntake.setSpeedCmd(Constants.INTAKE_SHOOTER.ALGAE_NET_SHOOT_SPEED),
@@ -170,8 +170,8 @@ public class ManipulatorCommands {
             //                     Logger.recordOutput("Manipulator/IntakeShooterState",
             // "ShootCoralL1")),
             //             myIntake.setSpeedCmd(Constants.INTAKE_SHOOTER.CORAL_SHOOT_SPEED),
-            //             myElevatorWrist.setPositionCmdNew(myIntakeLow,
-            // Constants.ELEVATOR.L1_FINAL, Constants.WRIST.L1)),
+            //             myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.L1_FINAL,
+            // Constants.WRIST.L1)),
             //         Commands.waitSeconds(Constants.INTAKE_SHOOTER.CORAL_L1_SHOOT_TIMEOUT),
             //         myIntake.setSpeedCmd(0),
             //         myIntakeLow.setSpeedCmd(0));
@@ -198,8 +198,7 @@ public class ManipulatorCommands {
         Commands.runOnce(() -> Constants.WRIST.POSITION_SCORING_ELEMENT = "Coral"),
         Commands.runOnce(() -> Logger.recordOutput("Manipulator/ElevatorWristState", "L4")),
         Commands.either(
-            myElevatorWrist.setPositionCmdNew(
-                myIntakeLow, Constants.ELEVATOR.L4, Constants.WRIST.L4),
+            myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.L4, Constants.WRIST.L4),
             Commands.none(),
             () -> {
               return ManipulatorCommands.havePiece || RobotContainer.m_climberBump;
@@ -212,8 +211,7 @@ public class ManipulatorCommands {
         Commands.runOnce(() -> Constants.WRIST.POSITION_SCORING_ELEMENT = "Coral"),
         Commands.runOnce(() -> Logger.recordOutput("Manipulator/ElevatorWristState", "L3")),
         Commands.either(
-            myElevatorWrist.setPositionCmdNew(
-                myIntakeLow, Constants.ELEVATOR.L3, Constants.WRIST.L3),
+            myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.L3, Constants.WRIST.L3),
             Commands.none(),
             () -> {
               return ManipulatorCommands.havePiece || RobotContainer.m_climberBump;
@@ -226,8 +224,7 @@ public class ManipulatorCommands {
         Commands.runOnce(() -> Constants.WRIST.POSITION_SCORING_ELEMENT = "Coral"),
         Commands.runOnce(() -> Logger.recordOutput("Manipulator/ElevatorWristState", "L2")),
         Commands.either(
-            myElevatorWrist.setPositionCmdNew(
-                myIntakeLow, Constants.ELEVATOR.L2, Constants.WRIST.L2),
+            myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.L2, Constants.WRIST.L2),
             Commands.none(),
             () -> {
               return ManipulatorCommands.havePiece || RobotContainer.m_climberBump;
@@ -240,8 +237,7 @@ public class ManipulatorCommands {
         Commands.runOnce(() -> Constants.WRIST.POSITION_SCORING_ELEMENT = "CoralL1"),
         Commands.runOnce(() -> Logger.recordOutput("Manipulator/ElevatorWristState", "L1")),
         Commands.either(
-            myElevatorWrist.setPositionCmdNew(
-                myIntakeLow, Constants.ELEVATOR.L1, Constants.WRIST.L1),
+            myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.L1, Constants.WRIST.L1, 1),
             Commands.none(),
             () -> {
               return ManipulatorCommands.havePiece || RobotContainer.m_climberBump;
@@ -253,8 +249,7 @@ public class ManipulatorCommands {
     return Commands.sequence(
         Commands.runOnce(() -> Constants.WRIST.POSITION_SCORING_ELEMENT = "Coral"),
         Commands.runOnce(() -> Logger.recordOutput("Manipulator/ElevatorWristState", "INTAKE")),
-        myElevatorWrist.setPositionCmdNew(
-            myIntakeLow, Constants.ELEVATOR.INTAKE, Constants.WRIST.INTAKE));
+        myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.INTAKE, Constants.WRIST.INTAKE));
   }
 
   public static Command AlgaeToNetCmd(
@@ -263,8 +258,7 @@ public class ManipulatorCommands {
         Commands.runOnce(() -> Constants.WRIST.POSITION_SCORING_ELEMENT = "AlgaeNet"),
         Commands.waitUntil(() -> algaeCradleFlag == false),
         Commands.runOnce(() -> Logger.recordOutput("Manipulator/ElevatorWristState", "NET")),
-        myElevatorWrist.setPositionCmdNew(
-            myIntakeLow, Constants.ELEVATOR.PRENET, Constants.WRIST.PRENET));
+        myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.PRENET, Constants.WRIST.PRENET, 1));
   }
 
   public static Command AlgaeToP1(
@@ -273,7 +267,7 @@ public class ManipulatorCommands {
         Commands.runOnce(() -> Constants.WRIST.POSITION_SCORING_ELEMENT = "Algae"),
         Commands.waitUntil(() -> algaeCradleFlag == false),
         Commands.runOnce(() -> Logger.recordOutput("Manipulator/ElevatorWristState", "P1")),
-        myElevatorWrist.setPositionCmdNew(myIntakeLow, Constants.ELEVATOR.P1, Constants.WRIST.P1));
+        myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.P1, Constants.WRIST.P1));
   }
 
   public static Command AlgaeAtA2(
@@ -282,7 +276,7 @@ public class ManipulatorCommands {
         Commands.runOnce(() -> Constants.WRIST.POSITION_SCORING_ELEMENT = "Algae"),
         Commands.waitUntil(() -> algaeCradleFlag == false),
         Commands.runOnce(() -> Logger.recordOutput("Manipulator/ElevatorWristState", "A2")),
-        myElevatorWrist.setPositionCmdNew(myIntakeLow, Constants.ELEVATOR.A2, Constants.WRIST.A2));
+        myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.A2, Constants.WRIST.A2));
   }
 
   public static Command AlgaeAtA1(
@@ -291,7 +285,7 @@ public class ManipulatorCommands {
         Commands.runOnce(() -> Constants.WRIST.POSITION_SCORING_ELEMENT = "Algae"),
         Commands.waitUntil(() -> algaeCradleFlag == false),
         Commands.runOnce(() -> Logger.recordOutput("Manipulator/ElevatorWristState", "A1")),
-        myElevatorWrist.setPositionCmdNew(myIntakeLow, Constants.ELEVATOR.A1, Constants.WRIST.A1));
+        myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.A1, Constants.WRIST.A1));
   }
 
   public static Command AlgaeCradle(
@@ -300,10 +294,8 @@ public class ManipulatorCommands {
         Commands.runOnce(() -> Constants.WRIST.POSITION_SCORING_ELEMENT = "Algae"),
         Commands.runOnce(
             () -> Logger.recordOutput("Manipulator/ElevatorWristState", "AlgaeCradle")),
-        myElevatorWrist.setPositionCmdNew(
-            myIntakeLow, Constants.ELEVATOR.MIN_POSITION, Constants.WRIST.SAFE),
-        myElevatorWrist.setPositionCmdNew(
-            myIntakeLow, Constants.ELEVATOR.MIN_POSITION, Constants.WRIST.CRADLE));
+        myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.MIN_POSITION, Constants.WRIST.SAFE),
+        myElevatorWrist.setPositionCmdNew(Constants.ELEVATOR.MIN_POSITION, Constants.WRIST.CRADLE));
   }
 
   public static Command DeployClimberCmd(RollerSystem myClimber) {
@@ -351,7 +343,7 @@ public class ManipulatorCommands {
         Commands.runOnce(() -> Constants.WRIST.POSITION_SCORING_ELEMENT = "Null"),
         Commands.runOnce(() -> Logger.recordOutput("Manipulator/ElevatorWristState", "ZERO")),
         myElevatorWrist.setPositionCmdNew(
-            myIntakeLow, Constants.ELEVATOR.MIN_POSITION, Constants.WRIST.MIN_POSITION));
+            Constants.ELEVATOR.MIN_POSITION, Constants.WRIST.MIN_POSITION));
   }
 
   public static Command FunctionalTest(

--- a/src/main/java/frc/robot/subsystems/ElevatorWristSubSystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorWristSubSystem.java
@@ -316,13 +316,16 @@ public class ElevatorWristSubSystem extends SubsystemBase {
                 Commands.sequence(
                     Commands.runOnce(
                         () -> Logger.recordOutput("Manipulator/Sequence1", "SLOWED WRIST")),
-                    Commands.runOnce(() -> wrist.setPosition(Constants.WRIST.SAFE, wristSlot)),
+                    Commands.runOnce(() -> wrist.setPosition(w_goal, wristSlot)),
                     Commands.runOnce(() -> elevator.setPosition(e_goal)),
-                    Commands.waitUntil(() -> elevator.atPosition()),
                     Commands.waitUntil(
                         () ->
                             (elevator.getPosition() >= Constants.ELEVATOR.MIN_MID_SAFE)
                                 || elevator.atPosition()));
+
+            // MAX_LOW_WRIST_MOVE_FROM_SAFE
+
+            // Commands.runOnce(() -> wrist.setPosition(w_goal, wristSlot)));
             // Commands.waitUntil(() -> wrist.atPosition()),
             // Commands.runOnce(() -> wrist.setPosition(w_goal, wristSlot)));
 

--- a/src/main/java/frc/robot/subsystems/rollers/RollerSystem.java
+++ b/src/main/java/frc/robot/subsystems/rollers/RollerSystem.java
@@ -9,6 +9,7 @@ package frc.robot.subsystems.rollers;
 
 import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.configs.Slot1Configs;
 import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Timer;
@@ -97,7 +98,7 @@ public class RollerSystem extends SubsystemBase {
         newconfig.kS = rollerkS.get();
         newconfig.kV = rollerkV.get();
         newconfig.kA = rollerkA.get();
-        io.setPID(newconfig);
+        setPID(newconfig);
       }
       if (rollerMMV.hasChanged(hashCode())
           || rollerMMA.hasChanged(hashCode())
@@ -126,13 +127,28 @@ public class RollerSystem extends SubsystemBase {
 
   // must call this once and only once in robotcontainer after each RollerSystem is created
   public void setPID(Slot0Configs newconfig) {
-    rollerkP.initDefault(newconfig.kP);
-    rollerkI.initDefault(newconfig.kI);
-    rollerkD.initDefault(newconfig.kD);
-    rollerkS.initDefault(newconfig.kS);
-    rollerkV.initDefault(newconfig.kV);
-    rollerkA.initDefault(newconfig.kA);
-    io.setPID(newconfig);
+    setPID(newconfig, null);
+  }
+
+  // must call this once and only once in robotcontainer after each RollerSystem is created
+  public void setPID(Slot0Configs config0, Slot1Configs config1) {
+    // slot0
+    rollerkP.initDefault(config0.kP);
+    rollerkI.initDefault(config0.kI);
+    rollerkD.initDefault(config0.kD);
+    rollerkS.initDefault(config0.kS);
+    rollerkV.initDefault(config0.kV);
+    rollerkA.initDefault(config0.kA);
+    // slot1
+    if (config1 != null) {
+      rollerkP.initDefault(config1.kP);
+      rollerkI.initDefault(config1.kI);
+      rollerkD.initDefault(config1.kD);
+      rollerkS.initDefault(config1.kS);
+      rollerkV.initDefault(config1.kV);
+      rollerkA.initDefault(config1.kA);
+    }
+    io.setPID(config0, config1);
   }
 
   // must call this once and only once in robotcontainer after each RollerSystem is created
@@ -172,13 +188,18 @@ public class RollerSystem extends SubsystemBase {
     return this.runOnce(() -> setSpeed(speed));
   }
 
-  @AutoLogOutput
   public void setPosition(double position) {
+    setPosition(position, 0);
+  }
+
+  @AutoLogOutput
+  public void setPosition(double position, int slot) {
     // in rotations
     setpoint = position;
-    io.setPosition(position, feedforward);
+    io.setPosition(position, feedforward, slot);
     Logger.recordOutput("RollerData/" + name + "/setpointPosition", setpoint);
     Logger.recordOutput("RollerData/" + name + "/feedforward", feedforward);
+    Logger.recordOutput("RollerData/" + name + "/slot", slot);
   }
 
   public double getSpeed() {

--- a/src/main/java/frc/robot/subsystems/rollers/RollerSystemIO.java
+++ b/src/main/java/frc/robot/subsystems/rollers/RollerSystemIO.java
@@ -9,6 +9,7 @@ package frc.robot.subsystems.rollers;
 
 import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.configs.Slot1Configs;
 import org.littletonrobotics.junction.AutoLog;
 
 public interface RollerSystemIO {
@@ -37,7 +38,7 @@ public interface RollerSystemIO {
   default void setPosition(double rotations) {}
 
   /* Run rollers at position with feedforward */
-  default void setPosition(double rotations, double feedforward) {}
+  default void setPosition(double rotations, double feedforward, int slot) {}
 
   /* Stop rollers */
   default void stop() {}
@@ -45,7 +46,7 @@ public interface RollerSystemIO {
   default void zero() {}
 
   /** Set P, I, and D gains for closed loop control on drive motor. */
-  public default void setPID(Slot0Configs newconfig) {}
+  public default void setPID(Slot0Configs config0, Slot1Configs config1) {}
 
   /** Set motion magic velocity, acceleration and jerk. */
   public default void setMotionMagic(MotionMagicConfigs newconfig) {}

--- a/src/main/java/frc/robot/subsystems/rollers/RollerSystemIOTalonFX.java
+++ b/src/main/java/frc/robot/subsystems/rollers/RollerSystemIOTalonFX.java
@@ -13,6 +13,7 @@ import com.ctre.phoenix6.BaseStatusSignal;
 import com.ctre.phoenix6.StatusSignal;
 import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.Slot0Configs;
+import com.ctre.phoenix6.configs.Slot1Configs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.controls.Follower;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;
@@ -148,8 +149,9 @@ public class RollerSystemIOTalonFX implements RollerSystemIO {
   }
 
   @Override
-  public void setPosition(double rotations, double feedforward) {
-    talon.setControl(mmvPosition.withPosition(rotations).withFeedForward(feedforward));
+  public void setPosition(double rotations, double feedforward, int slot) {
+    talon.setControl(
+        mmvPosition.withPosition(rotations).withFeedForward(feedforward).withSlot(slot));
     // System.out.println("\tFF set to: " + feedforward);
   }
 
@@ -165,13 +167,23 @@ public class RollerSystemIOTalonFX implements RollerSystemIO {
   }
 
   @Override
-  public void setPID(Slot0Configs newconfig) {
-    config.Slot0.kP = newconfig.kP;
-    config.Slot0.kI = newconfig.kI;
-    config.Slot0.kD = newconfig.kD;
-    config.Slot0.kS = newconfig.kS;
-    config.Slot0.kV = newconfig.kV;
-    config.Slot0.kA = newconfig.kA;
+  public void setPID(Slot0Configs config0, Slot1Configs config1) {
+    // slot0
+    config.Slot0.kP = config0.kP;
+    config.Slot0.kI = config0.kI;
+    config.Slot0.kD = config0.kD;
+    config.Slot0.kS = config0.kS;
+    config.Slot0.kV = config0.kV;
+    config.Slot0.kA = config0.kA;
+    // slot1
+    if (config1 != null) {
+      config.Slot1.kP = config1.kP;
+      config.Slot1.kI = config1.kI;
+      config.Slot1.kD = config1.kD;
+      config.Slot1.kS = config1.kS;
+      config.Slot1.kV = config1.kV;
+      config.Slot1.kA = config1.kA;
+    }
     tryUntilOk(5, () -> talon.getConfigurator().apply(config, 0.25));
   }
 


### PR DESCRIPTION
these are changes from the 'new branch start' I just sent.

mainly, this is trying to pull in Antonio's use of Slot1 for controlling wrist speed slower for L1 coral and I guess slower for shooting at net.

this is just for you to review.  I don't plan to merge with 'new branch start'.  
Since this is a sizeable change that effects all wrist movements and timings with elevator, I am hesitant to introduce for states.  
But maybe it is better at barge net shooting and will not lose our coral when going to L1 position.
I want to test this first thing Monday.
If working for L1 and barge shooting, then test all other positions manually and then run FunctionalTest and TestElevatorWristSequencing.

Background, I was having issue with wrist to L1 and did not try shoot at net.  L1 was ramming into elevator where going to A1 and A2 were not.  at the time I was trying to do first part of L1 to wrist safe position using slot0 configs and finish with slot1.  A1 and A2 are using just slot 0.  I think the switch from slot0 to slot1 that quick was trying to change wrist while it was moving which resulted in it not moving.  So, this latest revision here is untested and goes back to what Antonio has in this later check-ins used slot1 the whole times and not going to safe position first.

**additionally**  we may want these changes below regardless of the wrist change above
+in constants , X position to drive a bit closer to the barge for shooting
+signallogger.start.  we are getting .hoot files automatically at comps. but in shop practice, we are not.   I put where we had for 2024.  since we ran all of 2024 and both comps in 2025 with .hoot files being logged, I think we are fine to keep this change.

